### PR TITLE
Fix code typo

### DIFF
--- a/part-1.md
+++ b/part-1.md
@@ -181,7 +181,7 @@ JavaScript 1.0 的对象是关联数组，其元素称为属性。每个属性�
 // 使用 Object 构造函数
 var p1 = new Object;
 p1.x = 0;
-p2.y = 0;
+p1.y = 0;
 
 // 使用自定义的构造函数
 function Point(x, y) {


### PR DESCRIPTION
原书使用
![image](https://user-images.githubusercontent.com/36927158/143367341-52aa962a-0fa2-4a39-8890-0cfa82e976fd.png)
两个代码块命名 pt 来说明。 这里放在一起，所以区分了 p1 和 p2 。 但是第一段代码声明完 p1 时，显然应该对 p1 的 x y 分别操作。
```javascript
// 使用 Object 构造函数
var p1 = new Object;
p1.x = 0;
p2.y = 0; // p1 , right?

// 使用自定义的构造函数
function Point(x, y) {
  this.x = x;
  this.y = y;
}
var p2 = new Point(0, 0);
```